### PR TITLE
Pagination and confetti

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dosomething-modal": "^0.3.0",
     "lodash": "^4.17.4",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "react-dom-confetti": "0.0.8"
   },
   "devDependencies": {
     "@dosomething/babel-config": "^1.0.0",

--- a/resources/assets/app.scss
+++ b/resources/assets/app.scss
@@ -52,3 +52,7 @@ button.delete {
   font-weight: bold;
   margin-right: 5px;
 }
+
+.confetti {
+  margin-left: 50%;
+}

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -77,6 +77,7 @@ class CampaignInbox extends React.Component {
 
         // Update new state based on batch status
         this.checkBatch(newState);
+        
         return newState;
       });
     });
@@ -162,17 +163,21 @@ class CampaignInbox extends React.Component {
   }
 
   checkBatch(state) {
+    // Check if all posts in batch have been reviewed or deleted
     const reviewed = state.batch.every(key => {
       return !state.posts[key] || state.posts[key].status !== 'pending'
     });
     if (reviewed) {
+      // See if there are more posts to review in a later batch
       const pendingPostKeys = this.pendingPostKeys(state.posts);
       if (pendingPostKeys.length > 0) {
         state.displayGiveMeMore = true
       } else {
+        // If there are no more posts, display confetti without showing button
         state.shootConfetti = true
       }
     } else {
+      // Ensure the confetti status is reset
       state.shootConfetti = false
     }
   }
@@ -182,7 +187,9 @@ class CampaignInbox extends React.Component {
   }
 
   loadNextBatch() {
+    // Get all pending posts
     const pendingPostKeys = this.pendingPostKeys(this.state.posts)
+    // Use first 5 keys as current batch
     const nextBatch = pendingPostKeys.slice(0, 5)
     this.setState({
       shootConfetti: true,
@@ -209,6 +216,7 @@ class CampaignInbox extends React.Component {
         <div className="container">
 
           { batch.map(key => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: posts[key], campaign: campaign, signup: this.state.signups[posts[key].signup_id]}} />) }
+
           { this.state.displayGiveMeMore ? <button className="button" onClick={this.loadNextBatch}>Give me more</button> : null }
 
           <Confetti className="confetti" active={this.state.shootConfetti} config={confettiConfig} />

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -12,10 +12,12 @@ class CampaignInbox extends React.Component {
     super(props);
 
     const posts = extractPostsFromSignups(props.signups);
+    const batch = Object.keys(posts).slice(0, 5);
 
     this.state = {
       signups: keyBy(props.signups, 'id'),
       posts: posts,
+      batch: batch,
       displayHistoryModal: false,
       historyModalId: null,
     };
@@ -54,7 +56,6 @@ class CampaignInbox extends React.Component {
   // Updates a post status.
   updatePost(postId, fields) {
     fields.post_id = postId;
-
     let request = this.api.put('reviews', fields);
 
     request.then((result) => {
@@ -144,6 +145,7 @@ class CampaignInbox extends React.Component {
   }
 
   render() {
+    const batch = this.state.batch;
     const posts = this.state.posts;
     const campaign = this.props.campaign;
 
@@ -159,7 +161,7 @@ class CampaignInbox extends React.Component {
       return (
         <div className="container">
 
-          { map(posts, (post, key) => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: post, campaign: campaign, signup: this.state.signups[post.signup_id]}} />) }
+          { batch.map(key => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: posts[key], campaign: campaign, signup: this.state.signups[posts[key].signup_id]}} />) }
 
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -6,6 +6,15 @@ import { extractPostsFromSignups } from '../../helpers';
 import InboxItem from '../InboxItem';
 import ModalContainer from '../ModalContainer';
 import HistoryModal from '../HistoryModal';
+import Confetti from 'react-dom-confetti';
+
+const confettiConfig = {
+  angle: 90,
+  spread: 90,
+  startVelocity: 50,
+  elementCount: 70,
+  decay: 0.95
+};
 
 class CampaignInbox extends React.Component {
   constructor(props) {
@@ -21,6 +30,7 @@ class CampaignInbox extends React.Component {
       displayHistoryModal: false,
       historyModalId: null,
       displayGiveMeMore: false,
+      shootConfetti: false,
     };
 
     this.api = new RestApiClient;
@@ -160,8 +170,10 @@ class CampaignInbox extends React.Component {
       if (pendingPostKeys.length > 0) {
         state.displayGiveMeMore = true
       } else {
-        // @todo display confetti
+        state.shootConfetti = true
       }
+    } else {
+      state.shootConfetti = false
     }
   }
 
@@ -170,10 +182,10 @@ class CampaignInbox extends React.Component {
   }
 
   loadNextBatch() {
-    // @todo Display confetti
     const pendingPostKeys = this.pendingPostKeys(this.state.posts)
     const nextBatch = pendingPostKeys.slice(0, 5)
     this.setState({
+      shootConfetti: true,
       batch: nextBatch,
       displayGiveMeMore: false,
     })
@@ -192,16 +204,19 @@ class CampaignInbox extends React.Component {
       'https://media.giphy.com/media/lYHbL5QY52Kcw/giphy.gif',
     ];
 
-    if (posts.length !== 0) {
+    if (batch.length !== 0) {
       return (
         <div className="container">
 
           { batch.map(key => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: posts[key], campaign: campaign, signup: this.state.signups[posts[key].signup_id]}} />) }
           { this.state.displayGiveMeMore ? <button onClick={this.loadNextBatch}>Give me more</button> : null }
 
+          <Confetti className="confetti" active={this.state.shootConfetti} config={confettiConfig} />
+
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}
           </ModalContainer>
+
         </div>
       )
     } else {

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -11,8 +11,8 @@ import Confetti from 'react-dom-confetti';
 const confettiConfig = {
   angle: 90,
   spread: 90,
-  startVelocity: 50,
-  elementCount: 70,
+  startVelocity: 60,
+  elementCount: 90,
   decay: 0.95
 };
 
@@ -77,7 +77,7 @@ class CampaignInbox extends React.Component {
 
         // Update new state based on batch status
         this.checkBatch(newState);
-        
+
         return newState;
       });
     });

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -152,6 +152,10 @@ class CampaignInbox extends React.Component {
           // Remove the deleted post from the state
           delete(newState.posts[postId]);
 
+          // Remove the deleted post id/key from batch
+          const keyIndex = newState.batch.indexOf(String(postId));
+          newState.batch.splice(keyIndex, 1);
+
           // Update new state based on batch status
           this.checkBatch(newState);
 
@@ -163,9 +167,9 @@ class CampaignInbox extends React.Component {
   }
 
   checkBatch(state) {
-    // Check if all posts in batch have been reviewed or deleted
+    // Check if all posts in batch have been reviewed
     const reviewed = state.batch.every(key => {
-      return !state.posts[key] || state.posts[key].status !== 'pending'
+      return state.posts[key].status !== 'pending'
     });
     if (reviewed) {
       // See if there are more posts to review in a later batch

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -30,6 +30,7 @@ class CampaignInbox extends React.Component {
     this.showHistory = this.showHistory.bind(this);
     this.hideHistory = this.hideHistory.bind(this);
     this.deletePost = this.deletePost.bind(this);
+    this.loadNextBatch = this.loadNextBatch.bind(this);
   }
 
   // Open the history modal of the given post
@@ -168,6 +169,16 @@ class CampaignInbox extends React.Component {
     return reject(Object.keys(posts), key => posts[key].status !== 'pending');
   }
 
+  loadNextBatch() {
+    // @todo Display confetti
+    const pendingPostKeys = this.pendingPostKeys(this.state.posts)
+    const nextBatch = pendingPostKeys.slice(0, 5)
+    this.setState({
+      batch: nextBatch,
+      displayGiveMeMore: false,
+    })
+  }
+
   render() {
     const batch = this.state.batch;
     const posts = this.state.posts;
@@ -186,7 +197,7 @@ class CampaignInbox extends React.Component {
         <div className="container">
 
           { batch.map(key => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: posts[key], campaign: campaign, signup: this.state.signups[posts[key].signup_id]}} />) }
-          { this.state.displayGiveMeMore ? <button>Give me more</button> : null }
+          { this.state.displayGiveMeMore ? <button onClick={this.loadNextBatch}>Give me more</button> : null }
 
           <ModalContainer>
             {this.state.displayHistoryModal ? <HistoryModal id={this.state.historyModalId} onUpdate={this.updateQuantity} onClose={e => this.hideHistory(e)} details={{post: posts[this.state.historyModalId], campaign: campaign, signups: this.state.signups }}/> : null}

--- a/resources/assets/components/CampaignInbox/index.js
+++ b/resources/assets/components/CampaignInbox/index.js
@@ -209,7 +209,7 @@ class CampaignInbox extends React.Component {
         <div className="container">
 
           { batch.map(key => <InboxItem allowReview={true} onUpdate={this.updatePost} onTag={this.updateTag} showHistory={this.showHistory} deletePost={this.deletePost} key={key} details={{post: posts[key], campaign: campaign, signup: this.state.signups[posts[key].signup_id]}} />) }
-          { this.state.displayGiveMeMore ? <button onClick={this.loadNextBatch}>Give me more</button> : null }
+          { this.state.displayGiveMeMore ? <button className="button" onClick={this.loadNextBatch}>Give me more</button> : null }
 
           <Confetti className="confetti" active={this.state.shootConfetti} config={confettiConfig} />
 


### PR DESCRIPTION
@mirie 

#### What's this PR do?
Adds client side pagination to campaign review page, allowing the user to review 5 posts at a time and shooting confetti when the user chooses to load more posts to review, or completes review!

#### How should this be reviewed?
- Navigate to a campaign review page 
- Review all posts on page
- Button to 'Give me more' displayed
- Confetti shot and new posts loaded when button clicked
- Confetti shot when all posts reviewed

#### Any background context you want to provide?
DoSomething code challenge

#### Relevant tickets
Fulfilling specs defined here https://gist.github.com/mirie/0cbbf82a8650871f62ef20302e72a263

Please note that this does add some bloat to the Campaigns inbox component. A more optimal approach might employ the server side for pagination. I chose to implement on the client side to maintain the SPA feel to the review page.